### PR TITLE
[FIX] purchase_request: not allow to edit an approved purchase request

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -144,7 +144,7 @@
                     </group>
                     <notebook>
                         <page string="Products">
-                            <field name="line_ids">
+                            <field name="line_ids" readonly="state != 'draft'">
                                 <tree
                                     decoration-muted="cancelled == True"
                                     editable="bottom"


### PR DESCRIPTION
This commit fixes the the following issue.

- Create a purchase request with some products and send it to approval
- The manager approves the purchase request.
- After the approval the user can add new products to the request and can abuse